### PR TITLE
Fix NaN issue in `apply_lee_filter`

### DIFF
--- a/src/speckle_filters.py
+++ b/src/speckle_filters.py
@@ -19,7 +19,7 @@ def lee_filter(img, size):
     img_sqr_mean = uniform_filter(img**2, size)
     img_variance = img_sqr_mean - img_mean**2
 
-    overall_variance = np.var(img)
+    overall_variance = np.nanvar(img)
 
     img_weights = img_variance / (img_variance + overall_variance)
     img_output = img_mean + img_weights * (img - img_mean)
@@ -38,10 +38,9 @@ def apply_lee_filter(data_array, size=7):
     Returns:
     xarray.DataArray: The filtered data array.
     """
-    data_array_filled = data_array.fillna(0)
     filtered_data = xr.apply_ufunc(
         lee_filter,
-        data_array_filled,
+        data_array,
         kwargs={"size": size},
         input_core_dims=[["y", "x"]],
         output_core_dims=[["y", "x"]],


### PR DESCRIPTION
Before at the top is the output of the current `apply_lee_filter` fucntion, where NaN pixels are returned as 0.

At the bottom is the updated code, which correctly preserves NaN:
<img width="1215" height="388" alt="image" src="https://github.com/user-attachments/assets/734b9400-06ab-4824-a1b4-eb73ae573d05" />
